### PR TITLE
Fix floating point arithmatic in coloring script

### DIFF
--- a/scripts/color_diff.rb
+++ b/scripts/color_diff.rb
@@ -190,7 +190,12 @@ graph.each do |id,node|
 end
 
 # color each node accordingly
-factor = (max == 0) ? 0 : 0xff.to_f / max
+if max == 0
+  factor = 0
+else
+  factor = (0xff.to_f / max).finite? ? 0xff.to_f / max : 0
+end
+
 graph.each do |id,node|
   err = $relative ? node.relerr : node.abserr
   node.color -= (err * factor).round
@@ -204,7 +209,12 @@ clusters.each do |id,node|
 end
 
 # color each cluster accordingly
-factor = (max == 0) ? 0 : 0xff.to_f / max
+if max == 0
+  factor = 0
+else
+  factor = (0xff.to_f / max).finite? ? 0xff.to_f / max : 0
+end
+
 clusters.each do |name, cluster|
   err = $relative ? cluster.relerr : cluster.abserr
   cluster.color += (err * factor).round


### PR DESCRIPTION
Fixes: #8

## Fault
Very small error was being used as a denominator on an intermediate arithmetic operation to determine the color of nodes and
clusters.

## Testing
- tests/arith
- gauss from cs470 p3

# Environment
- Cluster
- pin-3.11-97998-g7ecce2dac-gcc-linux